### PR TITLE
Return measurements with microsecond precision

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,9 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    # Match Ubuntu release to Erlang release as per
+    # https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -7,7 +7,9 @@ on:
 jobs:
 
   credo:
-    runs-on: ubuntu-latest
+    # Match Ubuntu release to Erlang release as per
+    # https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
@@ -27,7 +29,8 @@ jobs:
       run: mix credo
 
   format:
-    runs-on: ubuntu-latest
+    # Likewise
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir

--- a/test/plug_telemetry_server_timing_test.exs
+++ b/test/plug_telemetry_server_timing_test.exs
@@ -42,7 +42,7 @@ defmodule Plug.ServerTimingTest do
     :telemetry.execute([:foo], %{bar: dur})
 
     assert [measure] = get_timings(conn)
-    assert {"foo.bar", %{"dur" => "2"}} = measure
+    assert {"foo.bar", %{"dur" => "2.000"}} = measure
   end
 
   @events {[:foo], :bar}
@@ -55,8 +55,8 @@ defmodule Plug.ServerTimingTest do
     :telemetry.execute([:bar], %{baz: 0})
 
     timings = get_timings(conn)
-    assert {"foo.bar", %{"dur" => "2"}} = List.keyfind(timings, "foo.bar", 0)
-    assert {"bar.baz", %{"dur" => "0"}} = List.keyfind(timings, "bar.baz", 0)
+    assert {"foo.bar", %{"dur" => "2.000"}} = List.keyfind(timings, "foo.bar", 0)
+    assert {"bar.baz", %{"dur" => "0.000"}} = List.keyfind(timings, "bar.baz", 0)
   end
 
   @events {[:foo], :bar}
@@ -64,12 +64,12 @@ defmodule Plug.ServerTimingTest do
   test "two measurements for same event are recorded" do
     conn = request()
 
-    dur = System.convert_time_unit(2, :millisecond, :native)
+    dur = System.convert_time_unit(2500, :microsecond, :native)
     :telemetry.execute([:foo], %{bar: dur, baz: 0})
 
     timings = get_timings(conn)
-    assert {"foo.bar", %{"dur" => "2"}} = List.keyfind(timings, "foo.bar", 0)
-    assert {"foo.baz", %{"dur" => "0"}} = List.keyfind(timings, "foo.baz", 0)
+    assert {"foo.bar", %{"dur" => "2.500"}} = List.keyfind(timings, "foo.bar", 0)
+    assert {"foo.baz", %{"dur" => "0.000"}} = List.keyfind(timings, "foo.baz", 0)
   end
 
   @events {[:foo], :bar, description: "Hi"}


### PR DESCRIPTION
Use native time unit for measurements and return measurements as floating point numbers with three decimals, giving microsecond resolution.

This also fixes the problem where "total" was converted from native to milliseconds twice, meaning that it would almost always be 0.